### PR TITLE
Fix artifactory access using the correct option (NO_JIRA)

### DIFF
--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -12,7 +12,7 @@
     --retries=100
     "--url=https://artifactory.ccdc.cam.ac.uk/artifactory"
     "--user={{ ansible_deployment_artifactory_user }}"
-    "--access-token={{ ansible_deployment_artifactory_key }}"
+    "--password={{ ansible_deployment_artifactory_key }}"
     "ccdc-3rdparty-macos-xcode-installers/Xcode_{{ xcode_version }}.xip"
     ~/Downloads/
   environment:


### PR DESCRIPTION
See the same fix in a different repo
https://github.com/ccdc-opensource/ansible-role-ccdc-expand-artifactory-archives/commit/d974b2dac119a3dcebbf3047419ff0dcc5f59054