### PR TITLE
Add gcc10 on RHEL (NO_JIRA)

### DIFF
--- a/files/enable-devtoolset.sh
+++ b/files/enable-devtoolset.sh
@@ -1,1 +1,1 @@
-source scl_source enable devtoolset-10
+source scl_source enable gcc-toolset-10

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -20,9 +20,9 @@
     mode: u=rwx,g=rx,o=rx
   become: true
 
-- name: Enable llvm-toolset globally for all users
-  ansible.builtin.copy:
-    src: enable-llvm-toolset.sh
-    dest: /etc/profile.d/enable-llvm-toolset.sh
-    mode: u=rwx,g=rx,o=rx
-  become: true
+# - name: Enable llvm-toolset globally for all users
+#   ansible.builtin.copy:
+#     src: enable-llvm-toolset.sh
+#     dest: /etc/profile.d/enable-llvm-toolset.sh
+#     mode: u=rwx,g=rx,o=rx
+#   become: true

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -7,6 +7,8 @@
       - clang
       - clang-tools-extra
       - git-clang-format
+      - gcc-toolset-10
+      - gcc-toolset-10-runtime
     state: present
   become: true
 


### PR DESCRIPTION
This should ensure gcc10 and related tools are installed and made the default on our new Rocky8 build machines.