### PR TITLE
Revert gcc back to 10 (BLD-7003)

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -7,16 +7,16 @@
       - clang
       - clang-tools-extra
       - git-clang-format
-      - gcc-toolset-14
-      - gcc-toolset-14-runtime
-      - gcc-toolset-14-libatomic-devel
+      - gcc-toolset-10
+      - gcc-toolset-10-runtime
+      - gcc-toolset-10-libatomic-devel
     state: present
   become: true
 
-- name: Create a symbolic link devtoolset-10 linking to gcc-toolset-14
+- name: Create a symbolic link devtoolset-10 linking to gcc-toolset-10
   ansible.builtin.file:
-    src: /opt/rh/gcc-toolset-14
-    dest: /opt/rh/devtoolset-14
+    src: /opt/rh/gcc-toolset-10
+    dest: /opt/rh/devtoolset-10
     owner: root
     group: root
     state: link


### PR DESCRIPTION
Some issues that require some time to deal in gcc 14. Stick with 10 for stable build. Investigate gcc 14 as a separate task.